### PR TITLE
Add a toggle option to grabber

### DIFF
--- a/io/include/pcl/io/grabber.h
+++ b/io/include/pcl/io/grabber.h
@@ -62,7 +62,7 @@ namespace pcl
       Grabber () {}
 
       /** \brief virtual destructor. */
-      virtual inline ~Grabber () throw ();
+      virtual inline ~Grabber ();
 
       /** \brief registers a callback function/method to a signal with the corresponding signature
         * \param[in] callback: the callback function/method
@@ -100,6 +100,13 @@ namespace pcl
         */
       virtual void 
       stop () = 0;
+   
+      /** \brief For devices that are streaming, stopped streams are started and running stream are stopped.
+        *        For triggered devices, the behavior is not defined.
+        * \return true if grabber is running / streaming. False otherwise.
+        */
+      inline bool
+      toggle ();
 
       /** \brief returns the name of the concrete subclass.
         * \return the name of the concrete driver.
@@ -151,10 +158,22 @@ namespace pcl
       std::map<std::string, std::vector<boost::signals2::shared_connection_block> > shared_connections_;
   } ;
 
-  Grabber::~Grabber () throw ()
+  Grabber::~Grabber ()
   {
     for (auto &signal : signals_)
       delete signal.second;
+  }
+ 
+  Grabber::toggle ()
+  {
+    if (isRunning ())
+    {
+      stop ();
+    } else
+    {
+      start ();
+    }
+    return isRunning ();
   }
 
   template<typename T> boost::signals2::signal<T>*


### PR DESCRIPTION
Easy way to toggle streaming devices. Works with concurrent controllers (dual `isRunning`)